### PR TITLE
Dev sync with jak - enable NVIDIA GPU by default 

### DIFF
--- a/hosts/default/config.nix
+++ b/hosts/default/config.nix
@@ -104,7 +104,7 @@
   # Extra Module Options
   drivers.amdgpu.enable = true;
   drivers.intel.enable = true;
-  drivers.nvidia.enable = false;
+  drivers.nvidia.enable = true;
   drivers.nvidia-prime = {
     enable = false;
     intelBusID = "";


### PR DESCRIPTION
# Pull Request

## Description

 Currently only the  AMD and Intel graphics adapters are enabled by default.   This patch will enable it.   NVIDIA users will need to do an extra step to get a working GUI on the initial build.   

## Type of change

Please put an `x` in the boxes that apply:

- [X ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/NixOS-Hyprland/blob/main/CONTRIBUTING.md) document.
- [ X] My code follows the code style of this project.
- [X ] My commit message follows the [commit guidelines](https://github.com/JaKooLit/NixOS-Hyprland/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in NixOS-Hyprland wiki.
- [ ] I have added tests to cover my changes.
- [ ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

(if appropriate)

## Additional context

I don't have a system with NVIDIA right now.  But enabling NVIDIA should not causes issues on systems without NVIDIA adapters.
