### PR TITLE
Update packages.nix - change btop to btop-rocm

### DIFF
--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -50,7 +50,7 @@
     xdg-utils
     #AGS version 2.x not backward compatible with v1 at this time
     #ags 
-    btop
+    btop-rocm
     cliphist
     eog
     feh


### PR DESCRIPTION

# Pull Request

## Description
This will add in the AMD ROCM library needed for  BTOP to also show GPU stats.  Same as what you get with NVIDIA.

## Type of change

- [X ] **New feature** (non-breaking change which adds functionality)

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/NixOS-Hyprland/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/JaKooLit/NixOS--
-  [X] I have tested my code locally and it works as expected.

## Screenshots

![image](https://github.com/user-attachments/assets/da0c27b1-1e28-4284-879d-c19932798dfc)

