### PR TITLE
Update config.nix   Boot loader timeout changed to 5 sec

### DIFF
--- a/hosts/default/config.nix
+++ b/hosts/default/config.nix
@@ -57,7 +57,7 @@
 	    canTouchEfiVariables = true;
   	  };
 
-    loader.timeout = 1;    
+    loader.timeout = 10;    
   			
     # Bootloader GRUB
     #loader.grub = {

--- a/hosts/default/config.nix
+++ b/hosts/default/config.nix
@@ -57,7 +57,7 @@
 	    canTouchEfiVariables = true;
   	  };
 
-    loader.timeout = 10;    
+    loader.timeout = 5;    
   			
     # Bootloader GRUB
     #loader.grub = {


### PR DESCRIPTION

# Pull Request

## Description
The default timeout of 1 second for the boot loader menu is too short.  Easy to miss it before booting starts. 

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/NixOS-Hyprland/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/NixOS-Hyprland/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [X] I have tested my code locally and it works as expected.


## Screenshots

(if appropriate)

## Additional context

Add any other context about the problem here.
