### PR TITLE
feat: don't change git global settings if they are already set

### DIFF
--- a/auto-install.sh
+++ b/auto-install.sh
@@ -112,6 +112,30 @@ sed -i 's/keyboardLayout\s*=\s*"\([^"]*\)"/keyboardLayout = "'"$keyboardLayout"'
 
 echo "-----"
 
+#Check if user already has git username set,
+#if they don't, request the user set them or select the defaults,
+#if they do, do nothing
+
+git_user=$(git config --global user.name)
+if [ -z "$git_user" ]; then
+  read -rp "$CAT Enter a username for Git: [ installer ] " git_user
+  if [ -z "$git_user" ]; then
+    git_user="installer"
+  fi
+  git config --global user.name ""$git_user""
+fi
+#Then do the same for git email
+git_email=$(git config --global user.email)
+if [ -z "$git_email" ]; then
+  read -rp "$CAT Enter an email for Git: [ installer@gmail.com ] " git_email
+  if [ -z "$git_email" ]; then
+    git_email="installer@gmail.com"
+  fi
+  git config --global user.email ""$git_email""
+fi
+
+echo "-----"
+
 installusername=$(echo $USER)
 sed -i 's/username\s*=\s*"\([^"]*\)"/username = "'"$installusername"'"/' ./flake.nix
 
@@ -141,9 +165,8 @@ done
 
 echo "-----"
 
-echo "$NOTE Setting Required Nix Settings Then Going To Install"
-git config --global user.name "installer"
-git config --global user.email "installer@gmail.com"
+echo "$NOTE Starting install..."
+
 git add .
 sed -i 's/host\s*=\s*"\([^"]*\)"/host = "'"$hostName"'"/' ./flake.nix
 

--- a/install.sh
+++ b/install.sh
@@ -82,6 +82,30 @@ sed -i 's/keyboardLayout\s*=\s*"\([^"]*\)"/keyboardLayout = "'"$keyboardLayout"'
 
 echo "-----"
 
+#Check if user already has git username set,
+#if they don't, request the user set them or select the defaults,
+#if they do, do nothing
+
+git_user=$(git config --global user.name)
+if [ -z "$git_user" ]; then
+  read -rp "$CAT Enter a username for Git: [ installer ] " git_user
+  if [ -z "$git_user" ]; then
+    git_user="installer"
+  fi
+  git config --global user.name ""$git_user""
+fi
+#Then do the same for git email
+git_email=$(git config --global user.email)
+if [ -z "$git_email" ]; then
+  read -rp "$CAT Enter an email for Git: [ installer@gmail.com ] " git_email
+  if [ -z "$git_email" ]; then
+    git_email="installer@gmail.com"
+  fi
+  git config --global user.email ""$git_email""
+fi
+
+echo "-----"
+
 installusername=$(echo $USER)
 sed -i 's/username\s*=\s*"\([^"]*\)"/username = "'"$installusername"'"/' ./flake.nix
 
@@ -111,9 +135,8 @@ done
 
 echo "-----"
 
-echo "$NOTE Setting Required Nix Settings Then Going To Install"
-git config --global user.name "installer"
-git config --global user.email "installer@gmail.com"
+echo "$NOTE Starting install..."
+
 git add .
 sed -i 's/host\s*=\s*"\([^"]*\)"/host = "'"$hostName"'"/' ./flake.nix
 


### PR DESCRIPTION
# Pull Request

## Description

Changed install.sh and auto-install.sh so that `git config --global` commands don't get called if they don't have to be.
Motivation: There is no need to change settings (especially global ones) if someone already has them set.

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/NixOS-Hyprland/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/JaKooLit/NixOS-Hyprland/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in NixOS-Hyprland wiki.
- [ ] I have added tests to cover my changes.
- [X] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.