### PR TITLE
home-manager: enable backups for conflicting files 

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,7 @@
             {
               home-manager.useGlobalPkgs = true;
               home-manager.useUserPackages = true;
+              home-manager.backupFileExtension = "hm-bak";
 
               # Ensure HM modules can access flake inputs (e.g., inputs.nixvim)
               home-manager.extraSpecialArgs = { inherit inputs system username host; };


### PR DESCRIPTION
# Pull Request

## Description
 Enabled Home Manager backups with home-manager.backupFileExtension = "hm-bak"
 Without this if Home manager tries to replace a file vs. a previous symbolic link, it will cause rebuilds to fail.
You then have to delete or rename the offending file(s) 
This backs up those files automatically 

## Type of change

Please put an `x` in the boxes that apply:

 - [X] **New feature** (non-breaking change which adds functionality)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/NixOS-Hyprland/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/NixOS-Hyprland/blob/main/CONTRIBUTING.md#git-commit-messages).
- [X] I have tested my code locally and it works as expected.
